### PR TITLE
Исправление в скрипте по настройке аудита и rsyslog

### DIFF
--- a/scripts/auditrules.sh
+++ b/scripts/auditrules.sh
@@ -29,10 +29,6 @@ sed -i "s/write_logs = no/write_logs = yes/g" /etc/audit/auditd.conf
 # Если нужно отключить локальную запись логов аудита
 # sed -i "s/write_logs = yes/write_logs = no/g" /etc/audit/auditd.conf
 
-# Настройка плагина audispd
-sed -i "s/active = no/active = yes/g" /etc/audisp/plugins.d/syslog.conf
-sed -i "s/args = LOG_INFO/args = LOG_LOCAL6/g" /etc/audisp/plugins.d/syslog.conf
-
 # В каталоге /etc/audit/rules.d для всех файлов с расширением rules измените расширение на любое другое
 for file in /etc/audit/rules.d/*.rules; do
     mv -- "$file" "${file%.rules}.new_extension"

--- a/scripts/auditrules.sh
+++ b/scripts/auditrules.sh
@@ -20,6 +20,18 @@
 # $ auditctl -a exit,always -S open -F path =/etc/ -F perm = aw
 # Аббревиатура aw означает следующее: а — изменение атрибута (attribute change), w — запись (write). Формулировка perm = aw указывает, что для директории /etc нужно отслеживать все факты изменения атрибутов (а — attribute change) и w (w — write).
 
+# Внести изменения в конфигурационный файл /etc/audit/auditd.conf
+sed -i "s/log_format = RAW/log_format = ENRICHED/g" /etc/audit/auditd.conf
+sed -i "s/name_format = NONE/name_format = NUMERIC/g" /etc/audit/auditd.conf
+sed -i "s/disp_qos = lossy/disp_qos = lossless/g" /etc/audit/auditd.conf
+sed -i "s/write_logs = no/write_logs = yes/g" /etc/audit/auditd.conf
+
+# Если нужно отключить локальную запись логов аудита
+# sed -i "s/write_logs = yes/write_logs = no/g" /etc/audit/auditd.conf
+
+# Настройка плагина audispd
+sed -i "s/active = no/active = yes/g" /etc/audisp/plugins.d/syslog.conf
+sed -i "s/args = LOG_INFO/args = LOG_LOCAL6/g" /etc/audisp/plugins.d/syslog.conf
 
 # В каталоге /etc/audit/rules.d для всех файлов с расширением rules измените расширение на любое другое
 for file in /etc/audit/rules.d/*.rules; do

--- a/scripts/rsyslog.sh
+++ b/scripts/rsyslog.sh
@@ -19,7 +19,7 @@ sudo echo "$RepeatedMsgReduction off" >> /etc/rsyslog.conf
 sudo echo "$imjournalRatelimitInterval 15" >> /etc/rsyslog.conf
 
 # 6. Добавление строки в конфигурационный файл /etc/systemd/journald.conf
-sudo sed -i 's/#RateLimitBurst= RateLimitBurst=/RateLimitBurst=20000/g' /etc/systemd/journald.conf
+sudo sed -i 's/#RateLimitBurst=.*/RateLimitBurst=20000/g' /etc/systemd/journald.conf
 
 # Перезапуск сервиса rsyslog для применения изменений
 sudo service rsyslog restart

--- a/scripts/rsyslog.sh
+++ b/scripts/rsyslog.sh
@@ -9,14 +9,14 @@ sudo chmod u=rw,g=r,o= /etc/rsyslog.d/10-siem.conf
 sudo echo "*.info;local6.*;mail.none;lpr.none;news.none;uucp.none;cron.none @${MP_IP_ADDRESS}:514" >> /etc/rsyslog.d/10-siem.conf
 
 # 3. Отключение сохранения событий службы auditd в файле /var/log/messages
-sudo echo ":programname, contains, "audisp" stop" >> /etc/rsyslog.d/10-siem.conf
+sudo echo ':programname, contains, "audisp" stop' >> /etc/rsyslog.d/10-siem.conf
 
 # 4. Раскомментирование строки $IncludeConfig в конфигурационном файле /etc/rsyslog.conf
 sudo sed -i 's/#$IncludeConfig /$IncludeConfig /g' /etc/rsyslog.conf
 
 # 5. Добавление строк в конфигурационный файл /etc/rsyslog.conf
-sudo echo "$RepeatedMsgReduction off" >> /etc/rsyslog.conf
-sudo echo "$imjournalRatelimitInterval 15" >> /etc/rsyslog.conf
+echo '$RepeatedMsgReduction off' | sudo tee -a /etc/rsyslog.conf
+echo '$imjournalRatelimitInterval 15' | sudo tee -a /etc/rsyslog.conf
 
 # 6. Добавление строки в конфигурационный файл /etc/systemd/journald.conf
 sudo sed -i 's/#RateLimitBurst=.*/RateLimitBurst=20000/g' /etc/systemd/journald.conf

--- a/scripts/syslogng.sh
+++ b/scripts/syslogng.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 MP_IP_ADDRESS=""
 # Создание файла 10-siem.conf и добавление в него необходимых настроек 
-sudo touch /etc/syslog-ng/10-siem.conf
-sudo chmod 666 /etc/syslog-ng/10-siem.conf
+sudo touch /etc/syslog-ng/conf.d/10-siem.conf
+sudo chmod 666 /etc/syslog-ng/conf.d/10-siem.conf
 
 echo 'filter pt_siem_filter { not facility(mail, lpr, news, uucp, cron); };
 destination siem_agent_udp { udp("${MP_IP_ADDRESS}" port(514)); };
-log { source(s_src); filter(pt_siem_filter); destination(siem_agent_udp); };' | sudo tee -a /etc/syslog-ng/10-siem.conf
+log { source(s_src); filter(pt_siem_filter); destination(siem_agent_udp); };' | sudo tee -a /etc/syslog-ng/conf.d/10-siem.conf
 
 # Добавление строки @include "10-siem.conf" в конфигурационный файл syslog-ng 
-sudo sed -i '/@include "scl.conf";/a @include "10-siem.conf";' /etc/syslog-ng/syslog-ng.conf
+# sudo sed -i '/@include "scl.conf";/a @include "10-siem.conf";' /etc/syslog-ng/syslog-ng.conf
 
 # Перезапуск службы syslog-ng
 sudo systemctl restart syslog-ng.service


### PR DESCRIPTION
В скрипт настройки аудита добавлена настройка формата логов в конфигурационном файле /etc/audit/auditd.conf\
В скрипте настройки rsyslog исправлены кавычки (3, 5 пункты), исправлена команда sed и в echo добавлена конструкция с tee -a 